### PR TITLE
Update to require pydantic >= 1.6.2

### DIFF
--- a/pyintacct/client.py
+++ b/pyintacct/client.py
@@ -4,7 +4,7 @@ import time
 from copy import deepcopy
 from jxmlease import parse, XMLDictNode, XMLCDATANode
 from pydantic import BaseModel
-from typing import List, Union
+from typing import List, Tuple, Union
 from uuid import uuid4
 from .exceptions import IntacctException, IntacctServerError
 from .models.base import API21Object
@@ -126,7 +126,7 @@ class IntacctAPI(object):
         else:
             return True
 
-    def get_session_id(self) -> str:
+    def get_session_id(self) -> Tuple[str, str, str]:
         payload = deepcopy(self.basexml)
         login = XMLDictNode({
             'userid': self.config['USER_ID'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jxmlease>=1.0.1
+jxmlease>=1.0.3
 requests>=2.22, <3.0
-pydantic==1.4
+pydantic >= 1.6.2, <2.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ LICENSE = 'MIT'
 AUTHOR = 'red-coracle'
 AUTHOR_EMAIL = ''
 URL = 'https://github.com/red-coracle/pyintacct'
-PYTHON_VERSION = '>=3.6.0'
+PYTHON_VERSION = '>=3.6.1'
 REQUIRES = ['requests >=2.22, <3.0',
-            'jxmlease >= 1.0.1',
-            'pydantic == 1.4']
+            'jxmlease >= 1.0.3',
+            'pydantic >= 1.6.2, <2.0.0']
 
 
 
@@ -40,5 +40,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8']
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9']
 )


### PR DESCRIPTION
Updates requirements to support versions of pydantic >= 1.6.2. This addresses a [low priority DoS vector](https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh) in pydantic.