### PR TITLE
Implement yield generator for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ client = IntacctAPI(config)
 customer = {'customer': {'CUSTOMERID': 'C-0001', 'NAME': 'Acme, Inc.'}}
 client.create(customer)
 
+# Query and return all results at once
 r = client.read_by_query('CUSTOMER', 'CUSTOMERID = \'C-0001\'', fields='NAME', pagesize=1)
+
+# Or iterate through pages
+r = client.yield_by_query('CUSTOMER', 'CUSTOMERID = \'C-0001\'', fields='NAME', pagesize=1)
+for customer in r:
+    print(customer['NAME'])
 ```
 
 You can also use pydantic models:

--- a/pyintacct/client.py
+++ b/pyintacct/client.py
@@ -147,6 +147,9 @@ class IntacctAPI(object):
         return str(sessionid.text), str(endpoint.text), str(timestamp.text)
 
     def read_by_query(self, obj: str, query: str, fields: str = '*', pagesize: int = 100, docparid: str = ''):
+        return list(self.yield_by_query(obj, query, fields, pagesize, docparid))
+
+    def yield_by_query(self, obj: str, query: str, fields: str = '*', pagesize: int = 100, docparid: str = ''):
         payload, function = self.get_function_base()
         function.add_node(tag='readByQuery', new_node=XMLDictNode({
             'object': obj,
@@ -154,16 +157,16 @@ class IntacctAPI(object):
             'query': query,
             'pagesize': pagesize,
             'docparid': docparid}))
-        results = list()
         r = self.execute(payload)
-        results.extend(r.find_nodes_with_tag(obj.lower()))
+        for record in r.find_nodes_with_tag(obj.lower()):
+            yield record
         data = next(r.find_nodes_with_tag('data'))
         remaining = data.get_xml_attr('numremaining')
         result_id = data.get_xml_attr('resultId')
         while int(remaining) > 0:
             data, remaining, result_id = self.read_more(result_id)
-            results.extend(data.find_nodes_with_tag(obj.lower()))
-        return results
+            for record in data.find_nodes_with_tag(obj.lower()):
+                yield record
 
     def read_more(self, result_id):
         payload, function = self.get_function_base()

--- a/pyintacct/client.py
+++ b/pyintacct/client.py
@@ -54,7 +54,7 @@ class IntacctAPI(object):
         self.headers = {'content-type': 'application/xml',
                         'accept-encoding': '*',
                         'user-agent': 'pyintacct-0.1.1'}
-        self.http_client = httpx.Client(headers=self.headers)
+        self.http_client = httpx.Client(headers=self.headers, timeout=30)
         self.basexml = parse(BASE_XML)
         self.basexml['request']['control'].update(XMLDictNode({
             'senderid': self.sender_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,8 @@
+import types
+
+from jxmlease import XMLDictNode
+from pydantic import BaseModel
+
 from pyintacct.client import IntacctAPI
 
 
@@ -18,3 +23,26 @@ def test_client_config_defaults():
     assert api.user_password is None
     assert api.session_expiration == 0
     assert api.basexml['request']['control']['senderid'] == 'sender_id'
+
+
+def test_read_by_query(client):
+    locations = client.read_by_query('LOCATION', query='', pagesize=100)
+    assert all(isinstance(location, XMLDictNode) for location in locations)
+
+
+def test_yield_by_query(client):
+    class Location(BaseModel):
+        LOCATIONID: str
+        NAME: str
+        PARENTID: str
+
+    results = client.yield_by_query('LOCATION', query='', pagesize=3)
+    assert isinstance(results, types.GeneratorType)
+    for result in results:
+        location = Location.parse_obj(result)
+        assert location.NAME != ''
+
+
+def test_yield_by_query_custom_object(client):
+    results = client.yield_by_query('asset', query='')
+    assert len(list(results)) == 0


### PR DESCRIPTION
- Allows consuming one page of results at a time
- Benchmark: a script parsing ~500 customers with a pagesize of 100 went from 60 MiB to 30 MiB peak memory